### PR TITLE
Rule updates

### DIFF
--- a/eslint.js
+++ b/eslint.js
@@ -5,9 +5,51 @@ module.exports = {
         "import/no-webpack-loader-syntax": "off",
         "no-plusplus": "off",
         "no-underscore-dangle": "off",
+        "consistent-return": "off",
+        "default-case": "off",
         "indent": [
             "error",
-            4
+            4,
+            {
+                "SwitchCase": 1,
+                "VariableDeclarator": 1,
+                "outerIIFEBody": 1,
+                "FunctionDeclaration": {
+                    "parameters": 1,
+                    "body": 1
+                },
+                "FunctionExpression": {
+                    "parameters": 1,
+                    "body": 1
+                },
+                "CallExpression": {
+                    "arguments": 1
+                },
+                "ArrayExpression": 1,
+                "ObjectExpression": 1,
+                "ImportDeclaration": 1,
+                "flatTernaryExpressions": false,
+                "ignoredNodes": [
+                    "JSXElement",
+                    "JSXElement > *",
+                    "JSXAttribute",
+                    "JSXIdentifier",
+                    "JSXNamespacedName",
+                    "JSXMemberExpression",
+                    "JSXSpreadAttribute",
+                    "JSXExpressionContainer",
+                    "JSXOpeningElement",
+                    "JSXClosingElement",
+                    "JSXFragment",
+                    "JSXOpeningFragment",
+                    "JSXClosingFragment",
+                    "JSXText",
+                    "JSXEmptyExpression",
+                    "JSXSpreadChild"
+                ],
+                "ignoreComments": false,
+                "offsetTernaryExpressions": false
+            }
         ],
         "eqeqeq": [
             "error",
@@ -82,7 +124,7 @@ module.exports = {
             4,
             {
                 "ignoreUrls": true,
-                "ignoreComments": false,
+                "ignoreComments": true,
                 "ignoreRegExpLiterals": true,
                 "ignoreStrings": true,
                 "ignoreTemplateLiterals": true


### PR DESCRIPTION
- Fixes indent, which the override removed other default settings such as switch case indent rules. I just added back the defaults that airbnb uses while keeping the 2->4 space change
- Turns off https://eslint.org/docs/rules/consistent-return
- Turns off https://eslint.org/docs/rules/default-case
- Ignore comments on https://eslint.org/docs/rules/max-len